### PR TITLE
Corrected endpoint for hist-orders.

### DIFF
--- a/lib/trade.js
+++ b/lib/trade.js
@@ -127,7 +127,7 @@ Trade.listFills = async function(params = {}) {
   }
 */
 Trade.getV1HistoricalOrders = async function(params = {}) {
-  let endpoint = 'api/v1/hist-orders'
+  let endpoint = '/api/v1/hist-orders'
   let url = this.baseURL + endpoint + this.formatQuery(params)
   let result = await axios.get(url, this.sign(endpoint, params, 'GET'))
   return result.data


### PR DESCRIPTION
There was a missing "/" which is causing the url to be malformed.