### PR TITLE
fixed websocket endpoint

### DIFF
--- a/lib/websockets.js
+++ b/lib/websockets.js
@@ -30,7 +30,7 @@ getSocketEndpoint = async function(type, baseURL, environment, sign) {
   if (environment === 'sandbox') {
     return `wss://push1-sandbox.kucoin.com/endpoint?token=${token}&[connectId=${Date.now()}]`
   } else if (environment === 'live') {
-    return `wss://push1-v2.kucoin.com/endpoint?token=${token}&[connectId=${Date.now()}]`
+    return `${r.data.instanceServers[0].endpoint}?token=${token}&[connectId=${Date.now()}]`
   }
 }
 


### PR DESCRIPTION
push1-v2 endpoint doesn't work anymore. The endpoint should be fetched from the response of the bullet call.