### PR TITLE
use endpoint of instance server returned by kucoin

### DIFF
--- a/lib/websockets.js
+++ b/lib/websockets.js
@@ -27,10 +27,16 @@ getSocketEndpoint = async function(type, baseURL, environment, sign) {
     r = await getPublicWsToken(baseURL)
   }
   let token = r.data.token
-  if (environment === 'sandbox') {
-    return `wss://push1-sandbox.kucoin.com/endpoint?token=${token}&[connectId=${Date.now()}]`
-  } else if (environment === 'live') {
-    return `${r.data.instanceServers[0].endpoint}?token=${token}&[connectId=${Date.now()}]`
+  let instanceServer = r.data.instanceServers[0]
+
+  if(instanceServer){
+    if (environment === 'sandbox') {
+      return `${instanceServer.endpoint}?token=${token}&[connectId=${Date.now()}]`
+    } else if (environment === 'live') {
+      return `${instanceServer.endpoint}?token=${token}&[connectId=${Date.now()}]`
+    }
+  }else{
+    throw Error("No Kucoin WS servers running")
   }
 }
 


### PR DESCRIPTION
As mentioned in https://github.com/escwdev/kucoin-node-api/issues/9 I was receiving an err for websockets. This PR will fix that and use the dynamic endpoints returned by Kucoin API