### PR TITLE
feat(multi-websocket): support unique key for ws by symbol

### DIFF
--- a/lib/websockets.js
+++ b/lib/websockets.js
@@ -5,21 +5,21 @@ const Sockets = {}
 Sockets.ws = {}
 Sockets.heartbeat = {}
 
-getPublicWsToken = async function(baseURL) {
+const getPublicWsToken = async function(baseURL) {
   let endpoint = '/api/v1/bullet-public'
   let url = baseURL + endpoint
   let result = await axios.post(url, {})
   return result.data
 }
 
-getPrivateWsToken = async function(baseURL, sign) {
+const getPrivateWsToken = async function(baseURL, sign) {
   let endpoint = '/api/v1/bullet-private'
   let url = baseURL + endpoint
   let result = await axios.post(url, {}, sign)
   return result.data
 }
 
-getSocketEndpoint = async function(type, baseURL, environment, sign) {
+const getSocketEndpoint = async function(type, baseURL, environment, sign) {
   let r
   if (type == 'private') {
     r = await getPrivateWsToken(baseURL, sign)

--- a/lib/websockets.js
+++ b/lib/websockets.js
@@ -26,12 +26,13 @@ getSocketEndpoint = async function(type, baseURL, environment, sign) {
   } else { 
     r = await getPublicWsToken(baseURL)
   }
+
   let token = r.data.token
   let instanceServer = r.data.instanceServers[0]
 
   if(instanceServer){
     if (environment === 'sandbox') {
-      return `${instanceServer.endpoint}?token=${token}&[connectId=${Date.now()}]`
+      return `${instanceServer.endpoint}/endpoint?token=${token}&[connectId=${Date.now()}]`
     } else if (environment === 'live') {
       return `${instanceServer.endpoint}?token=${token}&[connectId=${Date.now()}]`
     }
@@ -48,31 +49,41 @@ getSocketEndpoint = async function(type, baseURL, environment, sign) {
   }
   eventHanlder = function
 */
+
+Sockets.getSocketDictKey = function(topic, symbols){
+  return `${topic}:${JSON.stringify(symbols)}`
+}
+
 Sockets.initSocket = async function(params, eventHandler) {
   try {
     if ( !params.sign ) params.sign = false;
     if ( !params.endpoint ) params.endpoint = false;
     let [topic, endpoint, type] = Sockets.topics( params.topic, params.symbols, params.endpoint, params.sign )
+    const wsKey = Sockets.getSocketDictKey(topic, params.symbols);
+
     let sign = this.sign('/api/v1/bullet-private', {}, 'POST')
     let websocket = await getSocketEndpoint(type, this.baseURL, this.environment, sign)
     let ws = new WebSocket(websocket)
-    Sockets.ws[topic] = ws
+    Sockets.ws[wsKey] = ws
     ws.on('open', () => {
-      console.log(topic + ' opening websocket connection... ')
-      Sockets.subscribe(topic, endpoint, type, eventHandler)
-      Sockets.ws[topic].heartbeat = setInterval(Sockets.socketHeartBeat, 20000, topic)
+      console.log(wsKey + ' opening websocket connection... ')
+      Sockets.subscribe(wsKey, endpoint, type, eventHandler)
+      Sockets.ws[wsKey].heartbeat = setInterval(Sockets.socketHeartBeat, 1000, wsKey)
     })
     ws.on('error', (error) => {
       Sockets.handleSocketError(error)
       console.log(error)
     })
-    ws.on('ping', () => {
+    ws.on('ping', (cancel, data) => {
+      ws.send(data)
       return
     })
     ws.on('close', () => {
-      clearInterval(Sockets.ws[topic].heartbeat)
-      console.log(topic + ' websocket closed...')
+      clearInterval(Sockets.ws[wsKey].heartbeat)
+      console.log(wsKey + ' websocket closed...')
     })
+
+    return () => ws.close();
   } catch (err) {
     console.log(err)
   }
@@ -85,7 +96,7 @@ Sockets.handleSocketError = function(error) {
 
 Sockets.socketHeartBeat = function(topic) {
   let ws = Sockets.ws[topic]
-  ws.ping()
+  ws.ping(["ping"])
 }
 
 Sockets.subscribe = async function(topic, endpoint, type, eventHandler) {


### PR DESCRIPTION
# Description
I found that I could realistically only keep one websocket open as the topic was not unique enough so now using wsKey which has topic+symbol

# Changes 
- bug fix for older versions of js: adds const to function declarations missing a `var|const|let`
- adds `Socket.getSocketDictKey` which is unique topic key for `ws` by symbol
- use `/endpoint` for ws because wasn't working otherwise (API updates?)
- send `"ping"` explicitly to `ws` for heartbeat (might not be needed but was having issues w/ `ws` staying open)

# Notes
- Added /endpoint as the kucoin websocket api randomly stopped working for me. This is what I'm using locally and is working fine but maybe an original author can comment as why it worked for me and what I may have done wrong that necessitated making the change in the first. 
- Changes have **NOT** been tested after I rebased in with master