### PR TITLE
on 'websocket close' event-handler parameter added

### DIFF
--- a/lib/websockets.js
+++ b/lib/websockets.js
@@ -48,7 +48,7 @@ getSocketEndpoint = async function(type, baseURL, environment, sign) {
   }
   eventHanlder = function
 */
-Sockets.initSocket = async function(params, eventHandler) {
+Sockets.initSocket = async function(params, eventHandler, onCloseEventHandler) {
   try {
     if ( !params.sign ) params.sign = false;
     if ( !params.endpoint ) params.endpoint = false;
@@ -72,6 +72,7 @@ Sockets.initSocket = async function(params, eventHandler) {
     ws.on('close', () => {
       clearInterval(Sockets.ws[topic].heartbeat)
       console.log(topic + ' websocket closed...')
+      onCloseEventHandler()
     })
   } catch (err) {
     console.log(err)

--- a/lib/websockets.js
+++ b/lib/websockets.js
@@ -72,7 +72,9 @@ Sockets.initSocket = async function(params, eventHandler, onCloseEventHandler) {
     ws.on('close', () => {
       clearInterval(Sockets.ws[topic].heartbeat)
       console.log(topic + ' websocket closed...')
-      onCloseEventHandler()
+      if (onCloseEventHandler) {
+        onCloseEventHandler()
+      }
     })
   } catch (err) {
     console.log(err)


### PR DESCRIPTION
**Description**
Whenever a WebSocket connection closes (i.e. due to the interrupted internet connection), the app terminates if the stack is empty.

**AC**
- Optional event handler is provided so a closed WebSocket connection may be reinitialized instantly

**Notes**
this example method includes kucoin.initSocket call with the optional last argument passed into 'onCloseEventHandler' parameter:
`function startWSAllSymbolsTicker(
    callback
  ) {
    kucoin.init(apiConfig)
    kucoin.initSocket({ topic: 'allTicker' }, callback, () => {
      startWSAllSymbolsTicker(callback)
    })
  }`